### PR TITLE
Added tobilg/coreos-mesos-cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ What can you expect to see here?
 * [Go-Mesos-Utils](https://github.com/elodina/go-mesos-utils)
 
 ###Vagrant based setups
+* https://github.com/tobilg/coreos-mesos-cluster
 * https://github.com/everpeace/vagrant-mesos
 * https://github.com/mesosphere/playa-mesos 
 * https://github.com/bskaggs/vagrant-deimos


### PR DESCRIPTION
Added the `tobilg/coreos-mesos-cluster` to the list of Vagrant-based setups. This project creates a three-node CoreOS cluster (latest stable) with the following services:

* Apache ZooKeeper 3.4.6
* Mesos 0.28.0 (Masters / Slaves)
* Marathon 0.15.3